### PR TITLE
save content_entry_slug for ContentEntry

### DIFF
--- a/app/models/locomotive/content_entry.rb
+++ b/app/models/locomotive/content_entry.rb
@@ -6,8 +6,12 @@ Locomotive::ContentEntry.class_eval do
   search_by :options_for_search
   
   def options_for_search
-    store = [:_slug, _label_field_name, :site_id, :content_type_slug]
+    store = [:_slug, _label_field_name, :site_id, :content_type_slug, :content_entry_slug]
     content_type.entries_custom_fields.where(searchable: true).map(&:name) << {store: store}
+  end
+  
+  def content_entry_slug
+    _slug
   end
   
   def content_type_slug


### PR DESCRIPTION
I was unable to find a way to link to a `ContentEntry` in search results because the `_slug` gets filtered out of the returned `ActiveSearch::Result` (see `#initialize`), so I added `content_entry_slug` which lets us link to a `ContentEntry` from the liquid search template (let me know if there's some existing/better way to do this)
